### PR TITLE
Fix PremiumAdminCommand

### DIFF
--- a/dynamicpremium-commons/src/main/java/im/thatneko/dynamicpremium/commons/command/impl/PremiumAdminCommand.java
+++ b/dynamicpremium-commons/src/main/java/im/thatneko/dynamicpremium/commons/command/impl/PremiumAdminCommand.java
@@ -39,9 +39,9 @@ public class PremiumAdminCommand extends Command {
             );
             return;
         }
-        String subCommand = args[1];
+        String subCommand = args[0];
         if (subCommand.equals("toggle")) {
-            String name = args[2];
+            String name = args[1];
             CompletableFuture.runAsync(() -> {
                 boolean isPlayerPremium = this.dynamicPremium.getDatabaseManager().getDatabase().isPlayerPremium(name);
                 if (isPlayerPremium) {
@@ -51,13 +51,10 @@ public class PremiumAdminCommand extends Command {
                     this.dynamicPremium.getDatabaseManager().getDatabase().addPlayer(name);
                 }
                 dynamicPlayer.sendMessage(LegacyComponentSerializer.legacy('&').deserialize(
-                        messagesConfig.getString("admin.toggle." + (isPlayerPremium ? "disabled" : "enabled"))
+                        messagesConfig.getString("admin.toggled." + (isPlayerPremium ? "disabled" : "enabled"))
                                 .replace("%player%", name)
                 ));
             });
-            dynamicPlayer.sendMessage(LegacyComponentSerializer.legacy('&')
-                    .deserialize(messagesConfig.getString("admin.toggled.enabled"))
-            );
         }
     }
 }


### PR DESCRIPTION
Al hacer `/premiumadmin toggle <nick>` no imprime nada, pero al hacer `/premiumadmin toggle toggle <nick>` si que funciona porque los índices están mal puestos.

También he arreglado el mensaje que devuelve porque esta duplicado, y cambiado de `toggle` a `toggled` ya que es el que hay en la configuración.